### PR TITLE
Mark validator as async

### DIFF
--- a/lib/mongoose-validator-all.js
+++ b/lib/mongoose-validator-all.js
@@ -83,6 +83,7 @@ function multiValidate(options) {
    * error message respectively.
    */
   return {
+    isAsync: true,
     validator: validator,
     message: new ValidationErrorRetriever(),
     type: 'ValidationErrorRetriever'


### PR DESCRIPTION
As required by the new mongoose version: http://mongoosejs.com/docs/validation.html